### PR TITLE
0.2.5. Allow to use an object or a string as a plugin parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,26 @@
 # jquery-search-among
-Use input field to provide a quick search among list items, text paragraphs or another blocks of the web-page content. 
+Use input field to provide a quick search among list items, text paragraphs or another blocks of the web-page content.
 
 Specify multiple search terms, separated by spaces.
 
 As you enter characters, inappropriate items disappear.
 
-## Usage example
+## Options
+| Option         | Meaning |
+|----------------|---------|
+| sourceSelector | Selector of items, among which the search is performed. |
+
+You can use a string instead of an `options` object as a plugin parameter. In this case, the string will be interpreted as the value of the `sourceSelector` option.
+
+## Usage examples
 ```js
 jQuery(document).ready(function($) {
 
-    $('#search').searchAmong( $('.content').children('p') );
+    $('#search1').searchAmong('.content>p');
+
+    $('#search2').searchAmong({
+        sourceSelector: '.list>li',
+    });
 
 });
 ```

--- a/app/js/jquery-search-among.js
+++ b/app/js/jquery-search-among.js
@@ -2,7 +2,7 @@
  * jQuery Search Among Plugin
  * https://github.com/glebkema/jquery-search-among
  *
- * Version: 0.2.4
+ * Version: 0.2.5
  *
  * Copyright Gleb Kemarsky
  * Released under the MIT license.
@@ -10,14 +10,18 @@
 
 (function ($) {
 
-    $.fn.searchAmong = function(itemsSelector) {
+    $.fn.searchAmong = function(options) {
+        if ('string' === typeof options || options instanceof String) {
+            options = { sourceSelector: options };
+        }
+
         let searchWords = [];
 
         $(this).on('input', function() {
             let newWords = getWords(this.value);
             if (areArraysDifferent(searchWords, newWords)) {
                 searchWords = newWords;
-                let $items = $.find(itemsSelector);  // prevent the selector from being interpreted as HTML: https://lgtm.com/rules/1511421786841/
+                let $items = $.find(options.sourceSelector);  // prevent the selector from being interpreted as HTML: https://lgtm.com/rules/1511421786841/
                 if (searchWords) {
                     let count = searchWords.length;
                     for (let item of $items) {

--- a/app/js/jquery-search-among.js
+++ b/app/js/jquery-search-among.js
@@ -2,7 +2,7 @@
  * jQuery Search Among Plugin
  * https://github.com/glebkema/jquery-search-among
  *
- * Version: 0.2.3
+ * Version: 0.2.4
  *
  * Copyright Gleb Kemarsky
  * Released under the MIT license.
@@ -10,18 +10,19 @@
 
 (function ($) {
 
-    $.fn.searchAmong = function($items) {
+    $.fn.searchAmong = function(itemsSelector) {
         let searchWords = [];
 
         $(this).on('input', function() {
             let newWords = getWords(this.value);
             if (areArraysDifferent(searchWords, newWords)) {
-                console.log(newWords);
                 searchWords = newWords;
+                let $items = $.find(itemsSelector);  // prevent the selector from being interpreted as HTML: https://lgtm.com/rules/1511421786841/
                 if (searchWords) {
                     let count = searchWords.length;
                     for (let item of $items) {
-                        let text = $(item).text().toLowerCase();
+                        let $item = $(item);
+                        let text = $item.text().toLowerCase();
                         let isVisible = true;
                         for (let i = 0; i < count; i++) {
                             if (-1 === text.indexOf(searchWords[i])) {
@@ -29,7 +30,7 @@
                                 break;
                             }
                         }
-                        $(item).toggle(isVisible);
+                        $item.toggle(isVisible);
                     }
                 }
                 else {

--- a/dist/jquery-search-among.js
+++ b/dist/jquery-search-among.js
@@ -2,7 +2,7 @@
  * jQuery Search Among Plugin
  * https://github.com/glebkema/jquery-search-among
  *
- * Version: 0.2.4
+ * Version: 0.2.5
  *
  * Copyright Gleb Kemarsky
  * Released under the MIT license.
@@ -10,14 +10,18 @@
 
 (function ($) {
 
-    $.fn.searchAmong = function(itemsSelector) {
+    $.fn.searchAmong = function(options) {
+        if ("string" === typeof options || options instanceof String) {
+            options = { sourceSelector: options };
+        }
+
         let searchWords = [];
 
         $(this).on("input", function() {
             let newWords = getWords(this.value);
             if (areArraysDifferent(searchWords, newWords)) {
                 searchWords = newWords;
-                let $items = $.find(itemsSelector);  // prevent the selector from being interpreted as HTML: https://lgtm.com/rules/1511421786841/
+                let $items = $.find(options.sourceSelector);  // prevent the selector from being interpreted as HTML: https://lgtm.com/rules/1511421786841/
                 if (searchWords) {
                     let count = searchWords.length;
                     for (let item of $items) {

--- a/dist/jquery-search-among.js
+++ b/dist/jquery-search-among.js
@@ -2,7 +2,7 @@
  * jQuery Search Among Plugin
  * https://github.com/glebkema/jquery-search-among
  *
- * Version: 0.2.3
+ * Version: 0.2.4
  *
  * Copyright Gleb Kemarsky
  * Released under the MIT license.
@@ -10,18 +10,19 @@
 
 (function ($) {
 
-    $.fn.searchAmong = function($items) {
+    $.fn.searchAmong = function(itemsSelector) {
         let searchWords = [];
 
         $(this).on("input", function() {
             let newWords = getWords(this.value);
             if (areArraysDifferent(searchWords, newWords)) {
-                console.log(newWords);
                 searchWords = newWords;
+                let $items = $.find(itemsSelector);  // prevent the selector from being interpreted as HTML: https://lgtm.com/rules/1511421786841/
                 if (searchWords) {
                     let count = searchWords.length;
                     for (let item of $items) {
-                        let text = $(item).text().toLowerCase();
+                        let $item = $(item);
+                        let text = $item.text().toLowerCase();
                         let isVisible = true;
                         for (let i = 0; i < count; i++) {
                             if (-1 === text.indexOf(searchWords[i])) {
@@ -29,7 +30,7 @@
                                 break;
                             }
                         }
-                        $(item).toggle(isVisible);
+                        $item.toggle(isVisible);
                     }
                 }
                 else {

--- a/dist/jquery-search-among.min.js
+++ b/dist/jquery-search-among.min.js
@@ -2,9 +2,9 @@
  * jQuery Search Among Plugin
  * https://github.com/glebkema/jquery-search-among
  *
- * Version: 0.2.3
+ * Version: 0.2.4
  *
  * Copyright Gleb Kemarsky
  * Released under the MIT license.
  */
-!function(l){l.fn.searchAmong=function(i){let f=[];return l(this).on("input",function(){var t,n,e=function(t){if(""===(t=t.trim()))return[];t=t.toLowerCase().split(/\s+/);return function(n){n.sort(function(t,e){return e.length-t.length});let o=[],r=0;t:for(let t=0,e=n.length;t<e;t++){var i=n[t];for(let t=0;t<r;t++)if(-1<o[t].indexOf(i))continue t;o[r++]=i}return o}(t).sort()}(this.value);if(t=f,n=e,t.length!==n.length||t.some(function(t,e){return t!==n[e]}))if(console.log(e),f=e,f){var o,r=f.length;for(o of i){let e=l(o).text().toLowerCase(),n=!0;for(let t=0;t<r;t++)if(-1===e.indexOf(f[t])){n=!1;break}l(o).toggle(n)}}else i.show()}),this}}(jQuery);
+!function(l){l.fn.searchAmong=function(i){let f=[];return l(this).on("input",function(){var t,n,e=function(t){if(""===(t=t.trim()))return[];t=t.toLowerCase().split(/\s+/);return function(n){n.sort(function(t,e){return e.length-t.length});let r=[],o=0;t:for(let t=0,e=n.length;t<e;t++){var i=n[t];for(let t=0;t<o;t++)if(-1<r[t].indexOf(i))continue t;r[o++]=i}return r}(t).sort()}(this.value);if(t=f,n=e,t.length!==n.length||t.some(function(t,e){return t!==n[e]})){f=e;let t=l.find(i);if(f){var r,o=f.length;for(r of t){let t=l(r),e=t.text().toLowerCase(),n=!0;for(let t=0;t<o;t++)if(-1===e.indexOf(f[t])){n=!1;break}t.toggle(n)}}else t.show()}}),this}}(jQuery);

--- a/dist/jquery-search-among.min.js
+++ b/dist/jquery-search-among.min.js
@@ -2,9 +2,9 @@
  * jQuery Search Among Plugin
  * https://github.com/glebkema/jquery-search-among
  *
- * Version: 0.2.4
+ * Version: 0.2.5
  *
  * Copyright Gleb Kemarsky
  * Released under the MIT license.
  */
-!function(l){l.fn.searchAmong=function(i){let f=[];return l(this).on("input",function(){var t,n,e=function(t){if(""===(t=t.trim()))return[];t=t.toLowerCase().split(/\s+/);return function(n){n.sort(function(t,e){return e.length-t.length});let r=[],o=0;t:for(let t=0,e=n.length;t<e;t++){var i=n[t];for(let t=0;t<o;t++)if(-1<r[t].indexOf(i))continue t;r[o++]=i}return r}(t).sort()}(this.value);if(t=f,n=e,t.length!==n.length||t.some(function(t,e){return t!==n[e]})){f=e;let t=l.find(i);if(f){var r,o=f.length;for(r of t){let t=l(r),e=t.text().toLowerCase(),n=!0;for(let t=0;t<o;t++)if(-1===e.indexOf(f[t])){n=!1;break}t.toggle(n)}}else t.show()}}),this}}(jQuery);
+!function(l){l.fn.searchAmong=function(i){("string"==typeof i||i instanceof String)&&(i={sourceSelector:i});let f=[];return l(this).on("input",function(){var t,n,e=function(t){if(""===(t=t.trim()))return[];t=t.toLowerCase().split(/\s+/);return function(n){n.sort(function(t,e){return e.length-t.length});let r=[],o=0;t:for(let t=0,e=n.length;t<e;t++){var i=n[t];for(let t=0;t<o;t++)if(-1<r[t].indexOf(i))continue t;r[o++]=i}return r}(t).sort()}(this.value);if(t=f,n=e,t.length!==n.length||t.some(function(t,e){return t!==n[e]})){f=e;let t=l.find(i.sourceSelector);if(f){var r,o=f.length;for(r of t){let t=l(r),e=t.text().toLowerCase(),n=!0;for(let t=0;t<o;t++)if(-1===e.indexOf(f[t])){n=!1;break}t.toggle(n)}}else t.show()}}),this}}(jQuery);

--- a/tests/index.html
+++ b/tests/index.html
@@ -71,7 +71,7 @@
     <script src="../dist/jquery-search-among.js"></script>
     <script>
         jQuery(document).ready(function($) {
-            $('#search').searchAmong( $('.text>p,.list-group-item') ).focus();
+            $('#search').searchAmong('.text>p,.list-group-item').focus();
         });
     </script>
 </body>


### PR DESCRIPTION
0.2.4. Fix plugin safety: prevent the selector from being interpreted as HTML  
0.2.5. Allow to use an object or a string as a plugin parameter